### PR TITLE
refactor: misc type safety improvements

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -7,13 +7,23 @@
         "plugin:import/recommended",
         "plugin:import/typescript",
         "prettier",
-        "plugin:unicorn/all"
+        "plugin:unicorn/all",
+        "plugin:deprecation/recommended"
     ],
     "parserOptions": {
         "project": ["./tsconfig.json"]
     },
     "parser": "@typescript-eslint/parser",
-    "plugins": ["@typescript-eslint", "react-hooks", "react", "import", "prettier", "unicorn", "@cspell"],
+    "plugins": [
+        "@typescript-eslint",
+        "react-hooks",
+        "react",
+        "import",
+        "prettier",
+        "unicorn",
+        "@cspell",
+        "deprecation"
+    ],
     "rules": {
         // eslint overrides
         "arrow-body-style": "off",
@@ -135,7 +145,7 @@
         "react-hooks/exhaustive-deps": "error",
         "react-hooks/rules-of-hooks": "error",
         // this is great but has too many false positives
-        "react/jsx-no-leaked-render": "off",
+        "react/jsx-no-leaked-render": "error",
         "react/destructuring-assignment": "error",
         // It is often desirable to pass className
         "react/forbid-component-props": "off",
@@ -217,10 +227,15 @@
             }
         ],
 
-        "@typescript-eslint/max-params": ["error", {"max": 6}],
+        "@typescript-eslint/max-params": ["error", { "max": 6 }],
 
         // Potentially turning these on
-        "@typescript-eslint/prefer-readonly-parameter-types": "off",
+        "@typescript-eslint/prefer-readonly-parameter-types": [
+            "off",
+            {
+                "ignoreInferredTypes": true
+            }
+        ],
         "@typescript-eslint/explicit-function-return-type": "off",
         //"@typescript-eslint/no-magic-numbers": [
         //  "error",
@@ -228,8 +243,8 @@
         //],
         "@typescript-eslint/no-magic-numbers": "off",
         "@typescript-eslint/consistent-type-imports": "off",
-        "@typescript-eslint/sort-type-union-intersection-members": "off",
-        "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/sort-type-constituents": "error",
+        "@typescript-eslint/no-non-null-assertion": "error",
         // Enforced by TS
         "@typescript-eslint/init-declarations": "off",
         "@typescript-eslint/no-use-before-define": "off",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,6 +52,9 @@
         "webpack": "^5.76.2",
         "webpack-cli": "^5.0.1",
         "webpack-dev-server": "^5.0.0"
+      },
+      "devDependencies": {
+        "eslint-plugin-deprecation": "^2.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3772,6 +3775,121 @@
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-2.0.0.tgz",
+      "integrity": "sha512-OAm9Ohzbj11/ZFyICyR5N6LbOIvQMp7ZU2zI7Ej0jIc8kiGUERXPNMfw2QqqHD1ZHtjMub3yPZILovYEYucgoQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^6.0.0",
+        "tslib": "^2.3.1",
+        "tsutils": "^3.21.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0",
+        "typescript": "^4.2.4 || ^5.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -8412,6 +8530,27 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,8 +50,11 @@
   "scripts": {
     "start": "webpack serve",
     "build": "rimraf build && webpack build",
-    "lint": "eslint --cache --color ./src ./test webpack.*.ts playwright.*.ts && prettier --check ./src ./test webpack.*.ts playwright.*.ts",
+    "lint": "eslint --report-unused-disable-directives --cache --color ./src ./test webpack.*.ts playwright.*.ts && prettier --check ./src ./test webpack.*.ts playwright.*.ts",
     "fmt": "eslint --fix ./src ./test webpack.*.ts playwright.*.ts && prettier --write ./src ./test webpack.*.ts playwright.*.ts",
     "test": "curl -f -v -s -XPOST http://main.foxcaves:8080/api/v1/system/testing/reset && playwright test"
+  },
+  "devDependencies": {
+    "eslint-plugin-deprecation": "^2.0.0"
   }
 }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './app';
 import { config } from './utils/config';
+import { assert } from './utils/misc';
 
 if (config.no_render) {
     // eslint-disable-next-line no-console
@@ -22,7 +23,10 @@ if (config.no_render) {
         console.warn('Not loading sentry, no DSN!');
     }
 
-    const root = createRoot(document.getElementById('root')!);
+    const mountPoint = document.getElementById('root');
+    assert(mountPoint);
+
+    const root = createRoot(mountPoint);
 
     root.render(
         <React.StrictMode>

--- a/frontend/src/pages/account.tsx
+++ b/frontend/src/pages/account.tsx
@@ -7,11 +7,12 @@ import Modal from 'react-bootstrap/Modal';
 import { toast } from 'react-toastify';
 import { AppContext } from '../utils/context';
 import { useInputFieldSetter } from '../utils/hooks';
-import { logError } from '../utils/misc';
+import { assert, logError } from '../utils/misc';
 
 export const AccountPage: React.FC = () => {
     const { user, refreshUser, apiAccessor } = useContext(AppContext);
-    const userEmail = user!.email;
+    assert(user);
+    const userEmail = user.email;
 
     const [showDeleteAccountModal, setShowDeleteAccountModal] = useState(false);
     const [currentPassword, setCurrentPasswordCB] = useInputFieldSetter('');
@@ -28,7 +29,7 @@ export const AccountPage: React.FC = () => {
             body.current_password = currentPassword;
             try {
                 await toast.promise(
-                    apiAccessor.fetch(`/api/users/${encodeURIComponent(user!.id)}`, {
+                    apiAccessor.fetch(`/api/users/${encodeURIComponent(user.id)}`, {
                         method,
                         data: body,
                     }),
@@ -146,7 +147,7 @@ export const AccountPage: React.FC = () => {
                     />
                 </FloatingLabel>
                 <FloatingLabel className="mb-3" label="Username">
-                    <Form.Control name="username" placeholder="test_user" readOnly type="text" value={user!.username} />
+                    <Form.Control name="username" placeholder="test_user" readOnly type="text" value={user.username} />
                 </FloatingLabel>
                 <FloatingLabel className="mb-3" label="New password">
                     <Form.Control
@@ -184,7 +185,7 @@ export const AccountPage: React.FC = () => {
                                 placeholder="ABCDefgh"
                                 readOnly
                                 type="text"
-                                value={user!.api_key}
+                                value={user.api_key}
                             />
                             <Form.Label>API key</Form.Label>
                         </FloatingLabel>

--- a/frontend/src/pages/view.tsx
+++ b/frontend/src/pages/view.tsx
@@ -6,7 +6,7 @@ import { FileModel } from '../models/file';
 import { UserModel } from '../models/user';
 import { AppContext } from '../utils/context';
 import { formatDate } from '../utils/formatting';
-import { logError } from '../utils/misc';
+import { assert, logError } from '../utils/misc';
 
 const TextView: React.FC<{ readonly src: string }> = ({ src }) => {
     const [dataLoading, setDataLoading] = useState(false);
@@ -79,6 +79,7 @@ const FileContentView: React.FC<{ readonly file: FileModel }> = ({ file }) => {
 export const ViewPage: React.FC = () => {
     const { apiAccessor } = useContext(AppContext);
     const { id } = useParams<{ id: string }>();
+    assert(id);
     const [fileLoading, setFileLoading] = useState(false);
     const [fileLoadDone, setFileLoadDone] = useState(false);
     const [fileError, setFileError] = useState('');
@@ -87,7 +88,7 @@ export const ViewPage: React.FC = () => {
 
     const loadFile = useCallback(async () => {
         try {
-            const newFile = await FileModel.getById(id!, apiAccessor);
+            const newFile = await FileModel.getById(id, apiAccessor);
             if (newFile) {
                 setFile(newFile);
                 const newOwner = await UserModel.getById(newFile.owner, apiAccessor);

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -41,7 +41,7 @@ export class APIAccessor {
         return method === 'GET' || method === 'HEAD' || method === 'OPTIONS';
     }
 
-    public async refreshCSRFToken(): Promise<void> {
+    public async refreshCSRFToken(): Promise<string> {
         const res = (await this.fetch('/api/v1/system/csrf', {
             method: 'POST',
             data: { refresh: true },
@@ -49,14 +49,15 @@ export class APIAccessor {
         })) as CSRFRequestResponse;
 
         this.csrfToken = res.csrf_token;
+        return res.csrf_token;
     }
 
     public async getCSRFToken(): Promise<string> {
         if (!this.csrfToken) {
-            await this.refreshCSRFToken();
+            return this.refreshCSRFToken();
         }
 
-        return this.csrfToken!;
+        return this.csrfToken;
     }
 
     public async fetch(url: string, info?: APIRequestInfo): Promise<unknown> {

--- a/frontend/src/utils/misc.ts
+++ b/frontend/src/utils/misc.ts
@@ -14,3 +14,9 @@ export const sortByDate = (a: BaseModel, b: BaseModel): number => {
 export function noop(): void {
     // do nothing
 }
+
+export function assert(value: unknown): asserts value {
+    if (!value) {
+        throw new TypeError('assertion failed');
+    }
+}

--- a/frontend/src/utils/random.ts
+++ b/frontend/src/utils/random.ts
@@ -5,6 +5,7 @@ export function randomString(length = 10): string {
     let result = '';
     for (let i = 0; i < length; i++) {
         // This algorithm is NOT crypto secure, but it is good enough for our purposes
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         result += RNG_ALPHABET[u8[i]! % RNG_ALPHABET.length];
     }
 

--- a/frontend/test/files.spec.ts
+++ b/frontend/test/files.spec.ts
@@ -47,7 +47,8 @@ async function checkFile(src: string, page: Page): Promise<void> {
      * Assume we are on the file view page and check the file
      * Empty src == assume file is supposed to be gone
      */
-    const href = (await page.locator('p', { hasText: 'Direct link' }).locator('a').getAttribute('href'))!;
+    const href = await page.locator('p', { hasText: 'Direct link' }).locator('a').getAttribute('href');
+    assert(href);
     assert(href.includes('http://short.foxcaves:8080'));
 
     const fileRequest = await axios(href, {
@@ -82,7 +83,8 @@ testLoggedIn('Upload image file', async ({ page }) => {
     const file = fileLocator(filename, page);
 
     // Verify thumbnail exists and is a valid image
-    const src = (await file.locator('.card-img-top').getAttribute('src'))!;
+    const src = await file.locator('.card-img-top').getAttribute('src');
+    assert(src);
     assert(src.includes('http://short.foxcaves:8080'));
 
     const thumbnail = await axios(src, {
@@ -106,7 +108,8 @@ testLoggedIn('Upload non-image file', async ({ page }) => {
     const file = fileLocator(filename, page);
 
     // Verify there is no thumbnail
-    const src = (await file.locator('.card-img-top').getAttribute('src'))!;
+    const src = await file.locator('.card-img-top').getAttribute('src');
+    assert(src);
     assert(!src.includes('http://short.foxcaves:8080'));
 
     await viewAndCheckFile(filename, 'test.txt', page);
@@ -125,7 +128,8 @@ testLoggedIn('Delete file', async ({ browser, page }) => {
     const file = fileLocator(filename, page);
 
     // Verify file and thumbnail exist
-    const thumbnailSrc = (await file.locator('.card-img-top').getAttribute('src'))!;
+    const thumbnailSrc = await file.locator('.card-img-top').getAttribute('src');
+    assert(thumbnailSrc);
     assert(thumbnailSrc.includes('http://short.foxcaves:8080'));
     await axios(thumbnailSrc, {
         responseType: 'arraybuffer',

--- a/frontend/test/fixtures.ts
+++ b/frontend/test/fixtures.ts
@@ -18,7 +18,7 @@ async function getStoragePath(suffix: 'storage' | 'user'): Promise<string> {
 }
 
 export const testGuest = baseTest.extend<object, object>({
-    storageState: async (_, use) => {
+    storageState: async ({}, use) => {
         await use(undefined);
     },
 });
@@ -29,7 +29,7 @@ export const testLoggedIn = baseTest.extend<{ readonly testUser: TestUser }, { w
         await use(workerStorageState);
     },
 
-    testUser: async (_, use) => {
+    testUser: async ({}, use) => {
         await use(JSON.parse(await readFile(await getStoragePath('user'), 'utf8')) as TestUser);
     },
 

--- a/frontend/test/fixtures.ts
+++ b/frontend/test/fixtures.ts
@@ -18,6 +18,7 @@ async function getStoragePath(suffix: 'storage' | 'user'): Promise<string> {
 }
 
 export const testGuest = baseTest.extend<object, object>({
+    // eslint-disable-next-line no-empty-pattern
     storageState: async ({}, use) => {
         await use(undefined);
     },
@@ -29,6 +30,7 @@ export const testLoggedIn = baseTest.extend<{ readonly testUser: TestUser }, { w
         await use(workerStorageState);
     },
 
+    // eslint-disable-next-line no-empty-pattern
     testUser: async ({}, use) => {
         await use(JSON.parse(await readFile(await getStoragePath('user'), 'utf8')) as TestUser);
     },

--- a/frontend/test/fixtures.ts
+++ b/frontend/test/fixtures.ts
@@ -18,20 +18,18 @@ async function getStoragePath(suffix: 'storage' | 'user'): Promise<string> {
 }
 
 export const testGuest = baseTest.extend<object, object>({
-    // eslint-disable-next-line no-empty-pattern
-    storageState: async ({}, use) => {
+    storageState: async (_, use) => {
         await use(undefined);
     },
 });
 
-export const testLoggedIn = baseTest.extend<{ testUser: TestUser }, { workerStorageState: string }>({
+export const testLoggedIn = baseTest.extend<{ readonly testUser: TestUser }, { workerStorageState: string }>({
     // Use the same storage state for all tests in this worker.
     storageState: async ({ workerStorageState }, use) => {
         await use(workerStorageState);
     },
 
-    // eslint-disable-next-line no-empty-pattern
-    testUser: async ({}, use) => {
+    testUser: async (_, use) => {
         await use(JSON.parse(await readFile(await getStoragePath('user'), 'utf8')) as TestUser);
     },
 

--- a/frontend/test/links.spec.ts
+++ b/frontend/test/links.spec.ts
@@ -27,9 +27,10 @@ testLoggedIn('Create link', async ({ page }) => {
     const linkUrl = await createLink(page);
     const link = linkLocator(linkUrl, page);
     const shortUrl = await link.locator('a').nth(0).getAttribute('href');
-    assert(shortUrl?.includes('http://short.foxcaves:8080'));
+    assert(shortUrl);
+    assert(shortUrl.includes('http://short.foxcaves:8080'));
 
-    await page.goto(shortUrl!);
+    await page.goto(shortUrl);
     await page.waitForURL(linkUrl);
 });
 

--- a/frontend/test/utils.ts
+++ b/frontend/test/utils.ts
@@ -42,5 +42,5 @@ export async function doLoginPage(page: Page, user?: TestUser): Promise<TestUser
 }
 
 export function randomID(): string {
-    return randomUUID().split('-')[0]!;
+    return randomUUID().slice(0, 8);
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -30,7 +30,7 @@
         "resolveJsonModule": true,
         "isolatedModules": true,
         "noEmit": false,
-        "typeRoots": ["node_modules/@types", "types"],
+        "typeRoots": ["node_modules/@types", "types"]
     },
     "include": ["src", "test", "webpack.*.ts", "playwright.*.ts"]
 }

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -1,11 +1,8 @@
 import { join } from 'node:path';
-// eslint-disable-next-line import/default
 import ContentReplacePlugin from 'content-replace-webpack-plugin';
 // eslint-disable-next-line import/default
 import CopyPlugin from 'copy-webpack-plugin';
-// eslint-disable-next-line import/default
 import HtmlWebpackPlugin from 'html-webpack-plugin';
-// eslint-disable-next-line import/default
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import { Configuration, DefinePlugin } from 'webpack';
 import 'webpack-dev-server';


### PR DESCRIPTION
- Enabled `react/jsx-no-leaked-render` since we somehow have 0 violations.
- Partially applied `@typescript-eslint/prefer-readonly-parameter-types` but will keep off, way too many false positives.
- Added deprecation warning plugin.
- Removed all null assertions
- Improve protocol handling through string tuples
   - Needs protocol level type hits.
 